### PR TITLE
Use double quotes for the warning.

### DIFF
--- a/lib/forkcms_deploy/forkcms.rb
+++ b/lib/forkcms_deploy/forkcms.rb
@@ -78,9 +78,9 @@ configuration.load do
 			documentRootExists = capture("if [ ! -e #{document_root} ]; then ln -sf #{current_path}/default_www #{document_root}; echo 'no'; fi").chomp
 
 			unless documentRootExists == 'no'
-				warn 'Warning: Document root (#{document_root}) already exists'
-				warn 'to link it to the Fork deploy issue the following command:'
-				warn '	ln -sf #{current_path}/default_www #{document_root}'
+				warn "Warning: Document root (#{document_root}) already exists"
+				warn "to link it to the Fork deploy issue the following command:"
+				warn "	ln -sf #{current_path}/default_www #{document_root}"
 			end 
 		end	
 


### PR DESCRIPTION
Hi, in this commit the warning for an already existing document_root will be showed correctly by using double quotes. With single quotes it shows the string #{document_root} litteraly.
