### PR TITLE
Capitalize installer.txt symlink

### DIFF
--- a/lib/forkcms_deploy/forkcms_3.7.rb
+++ b/lib/forkcms_deploy/forkcms_3.7.rb
@@ -39,7 +39,7 @@ configuration.load do
 			# symlink the parameters
 			run %{
 				ln -sf #{shared_path}/config/parameters.yml #{release_path}/app/config/parameters.yml &&
-				ln -sf #{shared_path}/install/installed.txt #{release_path}/src/Install/Cache/installed.txt
+				ln -sf #{shared_path}/install/installed.txt #{release_path}/src/Install/Cache/Installed.txt
 			}
 		end
     


### PR DESCRIPTION
I was deploying a Fork CMS 3.8 website with Capistrano, but when I visited the website, it kept redirecting to /install. I found out that Fork CMS verifies that `Installed.txt` exists, if not: he redirects to /install.

However.. Forkcms_deploy creates a symlink `/src/Install/Cache/installed.txt` (with lowercase letters) so the website will only start working if you capitalize the txt file.