### PR TITLE
Dump an optimized autoloader.

### DIFF
--- a/lib/forkcms_deploy/forkcms_3.4.rb
+++ b/lib/forkcms_deploy/forkcms_3.4.rb
@@ -13,7 +13,7 @@ configuration.load do
 			composer.install_composer
 			run %{
 				cd #{latest_release} &&
-				php -d 'suhosin.executor.include.whitelist = phar' -d 'date.timezone = UTC' #{shared_path}/composer.phar install
+				php -d 'suhosin.executor.include.whitelist = phar' -d 'date.timezone = UTC' #{shared_path}/composer.phar install -o
 			}
 		end
 

--- a/lib/forkcms_deploy/forkcms_3.5.rb
+++ b/lib/forkcms_deploy/forkcms_3.5.rb
@@ -15,7 +15,7 @@ configuration.load do
 			composer.install_composer
 			run %{
 				cd #{latest_release} &&
-				php -d 'suhosin.executor.include.whitelist = phar' -d 'date.timezone = UTC' #{shared_path}/composer.phar install
+				php -d 'suhosin.executor.include.whitelist = phar' -d 'date.timezone = UTC' #{shared_path}/composer.phar install -o
 			}
 		end
 

--- a/lib/forkcms_deploy/forkcms_3.7.rb
+++ b/lib/forkcms_deploy/forkcms_3.7.rb
@@ -15,7 +15,7 @@ configuration.load do
 			composer.install_composer
 			run %{
 				cd #{latest_release} &&
-				php -d 'suhosin.executor.include.whitelist = phar' -d 'date.timezone = UTC' #{shared_path}/composer.phar install
+				php -d 'suhosin.executor.include.whitelist = phar' -d 'date.timezone = UTC' #{shared_path}/composer.phar install -o
 			}
 		end
 
@@ -42,7 +42,7 @@ configuration.load do
 				ln -sf #{shared_path}/install/installed.txt #{release_path}/src/Install/Cache/installed.txt
 			}
 		end
-    
+
 		desc 'Clear the frontend and backend cache-folders'
 		task :clear_cached do
 			# remove frontend cached data
@@ -67,7 +67,7 @@ configuration.load do
 				rm -rf #{current_path}/src/Backend/Cache/CompiledTemplates/*
 			}
 		end
-    
+
 		desc 'Create needed symlinks'
 		task :link_files do
 			# get the list of folders in /frontend/files
@@ -83,6 +83,6 @@ configuration.load do
 					ln -s #{shared_path}/files/#{folder} #{release_path}/src/Frontend/Files/#{folder}
 				}
 			end
-		end	
+		end
 	end
 end

--- a/lib/forkcms_deploy/forkcms_3.8.rb
+++ b/lib/forkcms_deploy/forkcms_3.8.rb
@@ -15,7 +15,7 @@ configuration.load do
 			composer.install_composer
 			run %{
 				cd #{latest_release} &&
-				php -d 'suhosin.executor.include.whitelist = phar' -d 'date.timezone = UTC' #{shared_path}/composer.phar install
+				php -d 'suhosin.executor.include.whitelist = phar' -d 'date.timezone = UTC' #{shared_path}/composer.phar install -o
 			}
 		end
 


### PR DESCRIPTION
This will improve the autoloading speed, since composer will create a
classmap instead of using file lookups.

From the docs: --optimize-autoloader (-o): Convert PSR-0/4 autoloading to classmap to get a faster autoloader. This is recommended especially for production, but can take a bit of time to run so it is currently not done by default.