### PR TITLE
Use skip-lock-tables to avoid long table locks.

### DIFF
--- a/lib/forkcms_deploy/forkcms_3.rb
+++ b/lib/forkcms_deploy/forkcms_3.rb
@@ -221,7 +221,7 @@ configuration.load do
 			parametersContent = capture "cat #{shared_path}/config/parameters.yml"
 			yaml = YAML::load(parametersContent.gsub("%", ""))
 
-			run "mysqldump --default-character-set='utf8' --host=#{yaml['parameters']['database.host']} --port=#{yaml['parameters']['database.port']} --user=#{yaml['parameters']['database.user']} --password=#{yaml['parameters']['database.password']} #{yaml['parameters']['database.name']} > #{release_path}/mysql_backup.sql"
+			run "mysqldump --skip-lock-tables --default-character-set='utf8' --host=#{yaml['parameters']['database.host']} --port=#{yaml['parameters']['database.port']} --user=#{yaml['parameters']['database.user']} --password=#{yaml['parameters']['database.password']} #{yaml['parameters']['database.name']} > #{release_path}/mysql_backup.sql"
 		end
 
 		desc 'puts back the database'


### PR DESCRIPTION
Some of our projects have rather big databases. Not locking these tables will make sure
our application doesn't have to wait for a long time during deployment.

A downside of this approach is the possibility of inconsistent data. During migrations, a
maintenance page is shown though, so this should not cause problems.