### PR TITLE
Running composer in no-dev modus fixes problems when deploying to Combell

### DIFF
--- a/lib/forkcms_deploy/forkcms_3.4.rb
+++ b/lib/forkcms_deploy/forkcms_3.4.rb
@@ -13,7 +13,7 @@ configuration.load do
 			composer.install_composer
 			run %{
 				cd #{latest_release} &&
-				php -d 'suhosin.executor.include.whitelist = phar' -d 'date.timezone = UTC' #{shared_path}/composer.phar install -o
+				php -d 'suhosin.executor.include.whitelist = phar' -d 'date.timezone = UTC' #{shared_path}/composer.phar install -o --no-dev
 			}
 		end
 


### PR DESCRIPTION
I tried lots of things and this one fixes my "deployment issues".

Fork CMS websites with DoctrineBundle and CustomBundles work perfect locally,
but when pushing using capistrano and this forkcms_deploy gem, errors are fatal causing nothing to work like expected on the server.

Problem:
```
 ** [out :: xxx] Stack trace:
 ** [out :: xxx] #0 /xxx/apps/production/releases/20160817130020/vendor/symfony/symfony/src/Symfony/Component/DependencyInjection/Compiler/CheckExceptionOnInvalidReferenceBehaviorPass.php(42): Symfony\Component\DependencyInjection\Compiler\CheckExceptionOnInvalidReferenceBehaviorPass->processReferences(Array)
 ** [out :: xxx] #1 /xxx/apps/production/releases/20160817130020/vendor/symfony/symfony/src/Symfony/Component/DependencyInjection/Compiler/CheckExceptionOnInvalidReferenceBehaviorPass.php(36): Symfony\Component\DependencyInjection\Compiler\CheckExceptionOnInvalidReferenceBeh in /xxx/apps/production/releases/20160817130020/vendor/symfony/symfony/src/Symfony/Component/DependencyInjection/Compiler/CheckExceptionOnInvalidReferenceBehaviorPass.php on line 58
 ** [out :: xxx] PHP Fatal error:  Uncaught exception 'Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException' with message 'The service "media.repository.gallery" has a dependency on a non-existent service "doctrine.orm.entity_manager".' in /xxx/apps/production/releases/20160817130020/vendor/symfony/symfony/src/Symfony/Component/DependencyInjection/Compiler/CheckExceptionOnInvalidReferenceBehaviorPass.php:58
 ** [out :: xxx] Stack trace:
 ** [out :: xxx] #0 /xxx/apps/production/releases/20160817130020/vendor/symfony/symfony/src/Symfony/Component/DependencyInjection/Compiler/CheckExceptionOnInvalidReferenceBehaviorPass.php(42): Symfony\Component\DependencyInjection\Compiler\CheckExceptionOnInvalidReferenceBehaviorPass->processReferences(Array)
 ** [out :: xxx] #1 /xxx/apps/production/releases/20160817130020/vendor/symfony/symfony/src/Symfony/Component/DependencyInjection/Compiler/CheckExceptionOnInvalidReferenceBehaviorPass.php(36): Symfony\Component\DependencyInjection\Compiler\CheckExceptionOnInvalidReferenceBeh in /xxx/apps/production/releases/20160817130020/vendor/symfony/symfony/src/Symfony/Component/DependencyInjection/Compiler/CheckExceptionOnInvalidReferenceBehaviorPass.php on line 58
```

Solution:
Adding `--no-dev` into the deployment fixed things.
The error is still shown, but there is no rollback and the website works fine!

Note:
I'm using the older wijs forkcms deploy to test things, so don't know if I placed the fix in the correct file.