### PR TITLE
Make the PHP-binary configurable

### DIFF
--- a/lib/forkcms_deploy/defaults.rb
+++ b/lib/forkcms_deploy/defaults.rb
@@ -16,6 +16,8 @@ configuration.load do
   # 3 releases should be enough.
   _cset(:keep_releases) { 3 }
 
+  _cset(:php_bin) { "php" }
+
   # remote caching will keep a local git repo on the server you're deploying to and simply run a fetch from that
   # rather than an entire clone. This is probably the best option and will only fetch the differences each deploy
   _cset(:deploy_via) { remote_cache }

--- a/lib/forkcms_deploy/forkcms_3.4.rb
+++ b/lib/forkcms_deploy/forkcms_3.4.rb
@@ -13,14 +13,14 @@ configuration.load do
 			composer.install_composer
 			run %{
 				cd #{latest_release} &&
-				php -d 'suhosin.executor.include.whitelist = phar' -d 'date.timezone = UTC' #{shared_path}/composer.phar install -o --no-dev
+				#{php_bin} -d 'suhosin.executor.include.whitelist = phar' -d 'date.timezone = UTC' #{shared_path}/composer.phar install -o --no-dev
 			}
 		end
 
 		desc 'Install composer'
 		task :install_composer do
 			run %{
-				if [ ! -e #{shared_path}/composer.phar ]; then cd #{shared_path}; curl -ks https://getcomposer.org/installer | php -d 'suhosin.executor.include.whitelist = phar' -d 'date.timezone = UTC'; fi
+				if [ ! -e #{shared_path}/composer.phar ]; then cd #{shared_path}; curl -ks https://getcomposer.org/installer | #{php_bin} -d 'suhosin.executor.include.whitelist = phar' -d 'date.timezone = UTC'; fi
 			}
 		end
 	end


### PR DESCRIPTION
When you have a server with multiple PHP-versions it is important to install the vendors with the correct php-binary.