### PR TITLE
Fixed a typo

### DIFF
--- a/lib/forkcms_deploy/forkcms_3.rb
+++ b/lib/forkcms_deploy/forkcms_3.rb
@@ -267,7 +267,7 @@ configuration.load do
 			run "touch #{document_root}/php-opcache-reset.php"
 			# clearstatcache(true) will clear the file stats cache and the realpath cache
 			# opache_reset will clear the opcache if this is available
-			run "echo \"<?php clearstatcache(true); if (function_exists('opache_reset')) { opcache_reset(); }\" > #{document_root}/php-opcache-reset.php"
+			run "echo \"<?php clearstatcache(true); if (function_exists('opcache_reset')) { opcache_reset(); }\" > #{document_root}/php-opcache-reset.php"
 			run %{ curl #{url}/php-opcache-reset.php }
 			run "rm #{document_root}/php-opcache-reset.php"
 		end


### PR DESCRIPTION
The `opcache_reset()` wasn't executed ever due a typo

Will fix https://github.com/sumocoders/forkcms_deploy/issues/23