### PR TITLE
No longer try to move sessions to the shared folder

### DIFF
--- a/lib/forkcms_deploy/forkcms_3.rb
+++ b/lib/forkcms_deploy/forkcms_3.rb
@@ -4,7 +4,7 @@ configuration = Capistrano::Configuration.respond_to?(:instance) ? Capistrano::C
 
 configuration.load do
 	# define some extra folder to create
-	set :shared_children, %w(files config/frontend config/backend config/library sessions)
+	set :shared_children, %w(files config/frontend config/backend config/library)
 
 	# custom events configuration
 	after 'deploy:setup' do
@@ -14,7 +14,6 @@ configuration.load do
 
 	after 'deploy:update_code' do
 		forkcms.link_configs
-		forkcms.link_sessions
 		forkcms.link_files
 	end
 
@@ -85,17 +84,6 @@ configuration.load do
 				ln -sf #{shared_path}/config/library/globals.php #{release_path}/library/globals.php &&
 				ln -sf #{shared_path}/config/frontend/config.php #{release_path}/frontend/cache/config/config.php &&
 				ln -sf #{shared_path}/config/backend/config.php #{release_path}/backend/cache/config/config.php
-			}
-		end
-
-		desc 'Link the session files'
-		task :link_sessions do
-
-			run %{
-				mkdir -p #{shared_path}/sessions &&
-				cp -r #{release_path}/app/sessions #{shared_path}/ &&
-				rm -rf #{release_path}/app/sessions &&
-				ln -s #{shared_path}/sessions #{release_path}/app/sessions
 			}
 		end
 


### PR DESCRIPTION
Since Fork 4, we've transitioned to a different method for storing sessions. That makes this code obsolete and frankly breaks the deploying.